### PR TITLE
Documentation and checks

### DIFF
--- a/R/check_data.R
+++ b/R/check_data.R
@@ -63,9 +63,18 @@ check_data <- function(data, silent = FALSE){
            Please provide a vector of length 12 indicating the proportion of spawning that occurs each month. \n
            Vector will aggregate according to data$Number_months_per_timestep.")
   }
+    if (!length(data$proportion_spawning) == 12) {
+    stop("Incorrect length of 'data$proportion_spawning' vector defined. \n
+           Please provide a vector of length 12 indicating the proportion of spawning that occurs each month. \n
+           Vector will aggregate according to data$Number_months_per_timestep.")
+  }
   # DATA_VECTOR(weight_at_recruitment);
   if (is.null(data$weight_at_recruitment)) {
     stop("No 'data$weight_at_recruitment' value defined. \n
+             Please provide a vector of length 2 indicating the weight of a pre-recruit and the weight of a recruit.")
+  }
+  if (!length(data$weight_at_recruitment) == 2) {
+    stop("Incorrect length of 'data$weight_at_recruitment' vector defined. \n
              Please provide a vector of length 2 indicating the weight of a pre-recruit and the weight of a recruit.")
   }
   # DATA_SCALAR(weight_inf);
@@ -104,7 +113,7 @@ check_data <- function(data, silent = FALSE){
              Please provide an array of standardised catch per unit effort standard deviation.")
   }
   if (!any(dim(data$cpue)==dim(data$cpue_sd))){
-    warning("Length of cpue and cpue_sd should match.")
+    warning("Dimension of cpue and cpue_sd should match.")
   }
   # DATA_VECTOR(month_sequence); # to be refined/removed in a later issue.
   if (is.null(data$month_sequence)) {
@@ -117,6 +126,9 @@ check_data <- function(data, silent = FALSE){
   }
   if (!is.null(data$rho_input) & data$calculate_rho == 1) {
     message(crayon::magenta("Ignoring data$rho_input. rho calculated inside the model using weight_at_recruitment and weight_inf."))
+  }
+  if (is.null(data$rho_input) & data$calculate_rho == 1) {
+    message(crayon::magenta("No 'data$absolute_biomass_sd' value defined. Using '1' by default but replaced by calculation in model."))
   }
   # DATA_INTEGER(calculate_rho);
   if (is.null(data$calculate_rho)) {

--- a/R/check_parameters.R
+++ b/R/check_parameters.R
@@ -10,6 +10,23 @@
 #' @param parameters list of parameters
 #' @param rec_dev_type Type of recruitment deviations: "barycentric", "redundant" or "none"
 #' @param silent TRUE to receive more information
+#' 
+#' 
+#' @description
+#' 'check_data' returns an amended list of model input parameters See details.
+#'
+#'
+#' @details
+#' The parameters you must specify include:
+#' - Rinit: virgin recruitment
+#' - h or xi: steepness or transformed steepness
+#' - M: natural mortality
+#' - mu, k: parameters (mean and 1/variance) of von Mises distribution
+#' - q1, q2: parameters for catchability pattern
+#' - lsigmaR_sq: measure of variance for recruitment deviations
+#' - lsigmaI_sq: measure of variance for abundance indices
+#' - zeta: recruitment deviations for 'barycentric' rec_dev_type
+#' - log_R_star: recruitment deviations for 'redundant' rec_dev_type
 #'
 #' @return updated list of parameters
 #' @export
@@ -33,7 +50,7 @@ check_parameters <- function(parameters, rec_dev_type, silent = FALSE){
              Please provide the initial value for the recruitment deviations.")
     }
     if (!is.null(parameters$log_R_star)){
-      if (!silent){message(crayon::magenta('Barycentric recruitment deviations specified, data$log_R_star will be ignored.'))}
+      if (!silent){message(crayon::magenta('Barycentric recruitment deviations specified, parameters$log_R_star will be ignored.'))}
     } else {
       parameters$log_R_star <- 0*parameters$zeta
     }

--- a/man/check_parameters.Rd
+++ b/man/check_parameters.Rd
@@ -17,7 +17,21 @@ check_parameters(parameters, rec_dev_type, silent = FALSE)
 updated list of parameters
 }
 \description{
-Check parameters for DDUST model
+'check_data' returns an amended list of model input parameters See details.
+}
+\details{
+The parameters you must specify include:
+\itemize{
+\item Rinit: virgin recruitment
+\item h or xi: steepness or transformed steepness
+\item M: natural mortality
+\item mu, k: parameters (mean and 1/variance) of von Mises distribution
+\item q1, q2: parameters for catchability pattern
+\item lsigmaR_sq: measure of variance for recruitment deviations
+\item lsigmaI_sq: measure of variance for abundance indices
+\item zeta: recruitment deviations for 'barycentric' rec_dev_type
+\item log_R_star: recruitment deviations for 'redundant' rec_dev_type
+}
 }
 \examples{
 parameters <- check_parameters(parameters, rec_dev_type = 'redundant')


### PR DESCRIPTION
1. In the check_data() function, the message for cpue and cpue_sd checks should replace the word 'length' with 'dimension'
2. If recruitment deviations are off, don't produce a warning about the length of zeta and log_R_star as these should be auto-filled
3. check weight_at_recruitment is a vector of length 2
4. check proportion_spawning is a vector of length 12
5. better documentation for check_parameters
6. check_data() should auto-fill rho_input